### PR TITLE
Update schemas.py

### DIFF
--- a/fastapi/schemas.py
+++ b/fastapi/schemas.py
@@ -14,10 +14,11 @@ class PagedCollection(BaseModel, Generic[T]):
         int,
         Field(
             ...,
-            desciption="Count of items into the system.\n "
-            "Replaces the total field which is deprecated",
-            validation_alias=AliasChoices("count", "total"),
-        ),
+            json_schema_extra={
+                'description': "Count of items into the system.\\nReplaces the total field which is deprecated",
+                'validation_alias': AliasChoices("count", "total")
+            }
+        )
     ]
     items: List[T]
 


### PR DESCRIPTION
replaced description with json_schema_extra

PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'desciption'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.4/migration/